### PR TITLE
Update Namespace Delimiter

### DIFF
--- a/docs/spec/common/formulas.md
+++ b/docs/spec/common/formulas.md
@@ -41,7 +41,7 @@ Operators are evaluated in the following order (highest to lowest):
 Variables and other resources can be referenced using either its id or namespace and id. When referencing a variable with its namespace, use the namespace path followed by a colon followed by the resource id:
 
 - Resource Id: `strength`
-- Namespaced reference: `character.stats:strength`
+- Namespaced reference: `character:stats:strength`
 
 ## Built-in Functions
 

--- a/docs/spec/structure/namespaces.md
+++ b/docs/spec/structure/namespaces.md
@@ -8,16 +8,24 @@ Some folder names are reserved and do not contribute to namespace paths. These f
 
 ## Namespace Path Specification
 
-Namespaces are specified using the path with dots (`.`) as segment separators. When referencing a namespace, the system will match to the closest matching namespace segment that aligns with the provided path. For instance, if referencing `combat.spells`, it will match the nearest namespace that ends with these segments.
+Namespaces are specified using the path with colons (`:`) as segment separators. When referencing a namespace, the system will match to the closest matching namespace segment that aligns with the provided path. For instance, if referencing `combat:spells`, the closest matching subnamespace to the current reference will be used.
 
 To avoid ambiguity in namespace resolution, it's recommended to use absolute paths that include all namespace segments from the root. This ensures precise and predictable namespace matching.
 
 ## Example Structure:
-```
+
+```plaintext
 /                   # Base namespace from metadata.json: example
 └─ data/            # Reserved directory
-   ├─ combat/       # Namespace: example.combat
-   │  ├─ spells/    # Namespace: example.combat.spells
-   │  └─ weapons/   # Namespace: example.combat.weapons
-   └─ characters/   # Namespace: example.characters
+   ├─ combat/       # Namespace: example:combat
+   │  ├─ spells/    # Namespace: example:combat:spells
+   │  └─ weapons/   # Namespace: example:combat:weapons
+   └─ characters/   # Namespace: example:characters
 ```
+
+## Version Support
+
+| Version | Support Level | Notes                                       |
+| ------- | ------------- | ------------------------------------------- |
+| 0.1.0   | ✅ Support    | Initial implementation                      |
+| 0.2.0   | ✅ Support    | Changed namespace delimiter from `.` to `:` |

--- a/docs/spec/structure/variables.md
+++ b/docs/spec/structure/variables.md
@@ -6,7 +6,7 @@ Variables are values that are stored within a RPGX file inside of `variables.jso
 
 Variables must be organized in `variables.json` files within the `data` directory. The path to the file should match the namespace of the variables. For example:
 
-- Variables in namespace `combat.stats` should be in `/data/combat/stats/variables.json`
+- Variables in namespace `combat:stats` should be in `/data/combat/stats/variables.json`
 - Variables in namespace `character` should be in `/data/character/variables.json`
 
 ## Structure
@@ -40,7 +40,7 @@ Variables are defined as JSON objects with specific properties that determine th
   "bonus": {
     "type": "number",
     "description": "Calculated bonus damage based on strength",
-    "value": "{floor(character.stats.strength / 2)}"
+    "value": "{floor(character:stats:strength / 2)}"
   },
   "isAlive": {
     "type": "boolean",
@@ -117,7 +117,7 @@ Values are validated against their declared type:
 | Type      | Valid Values         | Examples                                       |
 | --------- | -------------------- | ---------------------------------------------- |
 | `integer` | Whole numbers        | `5`, `{floor(3.7)}`                            |
-| `number`  | Any numeric value    | `3.14`, `{character.abilities:strength * 1.5}` |
+| `number`  | Any numeric value    | `3.14`, `{character:abilities:strength * 1.5}` |
 | `string`  | Text strings         | `"Hello"`, `{name + " " + title}`              |
 | `boolean` | True/false values    | `true`, `{health > 0}`                         |
 | `array`   | List of values       | `[]`, `[1,2,3]`, `[[], [1], [2]]`              |

--- a/docs/spec/toc.yml
+++ b/docs/spec/toc.yml
@@ -10,6 +10,8 @@
     href: structure/variables.md
   - name: Functions
     href: structure/functions.md
+  - name: Namespaces
+    href: structure/namespaces.md
 - name: Common
   items:
   - name: Data Types

--- a/examples/core.rpgxs/data/abilities/variables.json
+++ b/examples/core.rpgxs/data/abilities/variables.json
@@ -8,7 +8,7 @@
   "strengthModifier": {
     "type": "integer",
     "description": "Strength modifier",
-    "value": "{example.core.abilities:calcModifier(example.core.abilities.strength)}"
+    "value": "{example:core:abilities:calcModifier(example:core:abilities:strength)}"
   },
   "constitution": {
     "type": "integer",
@@ -18,7 +18,7 @@
   "constitutionModifier": {
     "type": "integer",
     "description": "Constitution modifier",
-    "value": "{example.core.abilities:calcModifier(example.core.abilities.constitution)}"
+    "value": "{example:core:abilities:calcModifier(example:core:abilities:constitution)}"
   },
   "intelligence": {
     "type": "integer",
@@ -28,6 +28,6 @@
   "intelligenceModifier": {
     "type": "integer",
     "description": "Intelligence modifier",
-    "value": "{example.core.abilities:calcModifier(example.core.abilities.intelligence)}"
+    "value": "{example:core:abilities:calcModifier(example:core:abilities:intelligence)}"
   }
 }

--- a/examples/core.rpgxs/data/stats/variables.json
+++ b/examples/core.rpgxs/data/stats/variables.json
@@ -3,12 +3,12 @@
   "health": {
     "type": "integer",
     "description": "Current health points",
-    "value": "{example.core.stats:maxHealth}"
+    "value": "{example:core:stats:maxHealth}"
   },
   "maxHealth": {
     "type": "integer",
     "description": "Maximum health points",
-    "value": "{example.core.abilities:constitution * level}"
+    "value": "{example:core:abilities:constitution * level}"
   },
   "experience": {
     "type": "integer",

--- a/examples/core.rpgxs/metadata.json
+++ b/examples/core.rpgxs/metadata.json
@@ -5,7 +5,7 @@
   "description": "Basic example of core rules and statistics for a tabletop RPG system",
   "version": "0.1.0",
   "type": "source",
-  "namespace": "example.core",
+  "namespace": "example:core",
   "rpgxVersion": "0.1.0",
   "authors": [
     {

--- a/examples/fantasy.rpgxs/data/stats/variables.json
+++ b/examples/fantasy.rpgxs/data/stats/variables.json
@@ -8,11 +8,11 @@
   "maxMagic": {
     "type": "integer",
     "description": "Maximum magical energy points",
-    "value": "{example.core.abilities:constitution * examples.core.stats:level}"
+    "value": "{example:core:abilities:constitution * examples:core:stats:level}"
   },
   "knownSpells": {
     "type": "integer",
     "description": "Number of spells known",
-    "value": "{10 + example.core.abilities:intelligenceModifier}"
+    "value": "{10 + example:core:abilities:intelligenceModifier}"
   }
 }

--- a/examples/fantasy.rpgxs/metadata.json
+++ b/examples/fantasy.rpgxs/metadata.json
@@ -5,7 +5,7 @@
   "description": "Fantasy-themed RPG rules and statistics",
   "version": "0.1.0",
   "type": "source",
-  "namespace": "example.fantasy",
+  "namespace": "example:fantasy",
   "rpgxVersion": "0.1.0",
   "dependencies": [
     {

--- a/examples/sci_fi.rpgxs/metadata.json
+++ b/examples/sci_fi.rpgxs/metadata.json
@@ -4,7 +4,7 @@
   "description": "Science fiction rules and statistics",
   "version": "0.1.0",
   "type": "source",
-  "namespace": "example.sci_fi",
+  "namespace": "example:sci_fi",
   "rpgxVersion": "0.1.0",
   "dependencies": [
     {


### PR DESCRIPTION
Updated namespace delimiter to use colon instead of period to reflect a more consistent format and distinguish between selecting a namespaced value and an object property.